### PR TITLE
Change checksum return to Map

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,7 +1,6 @@
 {
   "General": {
-    "checksums": ["MD5", "SHA-1", "SHA-256", "SHA-512"],
-    "fail_fast": false
+    "checksums": ["MD5", "SHA-1", "SHA-256", "SHA-512"]
   },
   "Validations": {
     "SmallDocuments": {

--- a/docs/classdev_1_1filechampion_1_1filechampion4j_1_1_validation_response.html
+++ b/docs/classdev_1_1filechampion_1_1filechampion4j_1_1_validation_response.html
@@ -498,7 +498,7 @@ Private Attributes</h2></td></tr>
 
 <p class="definition">Definition at line <a class="el" href="_validation_response_8java_source.html#l00013">13</a> of file <a class="el" href="_validation_response_8java_source.html">ValidationResponse.java</a>.</p>
 
-<p class="reference">Referenced by <a class="el" href="_validation_response_8java_source.html#l00026">dev.filechampion.filechampion4j.ValidationResponse.ValidationResponse()</a>, and <a class="el" href="_validation_response_8java_source.html#l00080">dev.filechampion.filechampion4j.ValidationResponse.getFileChecksum()</a>.</p>
+<p class="reference">Referenced by <a class="el" href="_validation_response_8java_source.html#l00026">dev.filechampion.filechampion4j.ValidationResponse.ValidationResponse()</a>, and <a class="el" href="_validation_response_8java_source.html#l00080">dev.filechampion.filechampion4j.ValidationResponse.getFileChecksums()</a>.</p>
 
 </div>
 </div>

--- a/pom-release.xml
+++ b/pom-release.xml
@@ -37,7 +37,7 @@
 
     <scm>
         <connection>scm:git:git://github.com/povimd9/FileChampion4j.git</connection>
-        <url>https://github.com/povimd9/FileChampion4j/tree/release-0.9.8.2</url>
+        <url>https://github.com/povimd9/FileChampion4j/tree/release-0.9.8.3</url>
     </scm>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
     <scm>
         <connection>scm:git:git://github.com/povimd9/FileChampion4j.git</connection>
-        <url>https://github.com/povimd9/FileChampion4j/tree/release-0.9.8.2</url>
+        <url>https://github.com/povimd9/FileChampion4j/tree/release-0.9.8.3</url>
     </scm>
 
     <properties>

--- a/src/main/java/dev/filechampion/filechampion4j/Extensions.java
+++ b/src/main/java/dev/filechampion/filechampion4j/Extensions.java
@@ -50,6 +50,7 @@ public class Extensions {
     private Map<String, Object> validationCache = new HashMap<>();
     private String sharedMessage1 = "Unsupported value type: ";
     private String sharedMessage2 = " for key: ";
+    // Allowed key values from the json Validations object
     private List<String> allowedKeyValues = Arrays.asList("mime_type", "magic_bytes", "header_signatures", 
         "footer_signatures", "change_ownership", "change_ownership_user", "change_ownership_mode",
         "name_encoding", "max_size", "extension_plugins", "add_checksum", "fail_fast");

--- a/src/main/java/dev/filechampion/filechampion4j/ValidationResponse.java
+++ b/src/main/java/dev/filechampion/filechampion4j/ValidationResponse.java
@@ -11,7 +11,7 @@ public class ValidationResponse {
     private final String resultsDetails;
     private final String cleanFileName;
     private final byte[] fileBytes;
-    private final Map<String, String> fileChecksum;
+    private final Map<String, String> fileChecksums;
     private final String[] validFilePath;
 
     /**
@@ -21,15 +21,15 @@ public class ValidationResponse {
     * @param resultsDetails (String) a String containing the details of the validation
     * @param cleanFileName (String) the file name with all special characters replaced with underscores
     * @param fileBytes (bytes[]) the file bytes
-    * @param fileChecksum (Map<String, String>) hash map containing the file checksums as 'algorithm' => 'checksum'
+    * @param fileChecksums (Map&lt;String, String&gt;) hash map containing the file checksums as 'algorithm' =&gt; 'checksum'
     * @param validFilePath (String) optional valid file path if outputDir was set in the filechampion4j constructor
     */
-    public ValidationResponse(boolean isValid, String resultsInfo, String resultsDetails, String cleanFileName, byte[] fileBytes, Map<String, String> fileChecksum, String... validFilePath) {
+    public ValidationResponse(boolean isValid, String resultsInfo, String resultsDetails, String cleanFileName, byte[] fileBytes, Map<String, String> fileChecksums, String... validFilePath) {
         this.isValid = isValid;
         this.resultsInfo = resultsInfo;
         this.resultsDetails = resultsDetails;
         this.fileBytes = fileBytes;
-        this.fileChecksum = fileChecksum.size() > 0 ? fileChecksum : null;
+        this.fileChecksums = fileChecksums;
         this.validFilePath = validFilePath;
         this.cleanFileName = cleanFileName;
     }
@@ -78,8 +78,8 @@ public class ValidationResponse {
      * Returns the file SHA-256 checksum
      * @return (String) the file checksum
      */
-    public Map<String, String> getFileChecksum() {
-        return fileChecksum;
+    public Map<String, String> getFileChecksums() {
+        return fileChecksums;
     }
 
     /**

--- a/src/main/java/dev/filechampion/filechampion4j/ValidationsHelper.java
+++ b/src/main/java/dev/filechampion/filechampion4j/ValidationsHelper.java
@@ -14,7 +14,7 @@ import java.util.logging.LogManager;
 
 /**
  * This class contains helper methods for the FileValidator class
- * @version 0.9.8.2
+ * @version 0.9.8.3
  */
 public class ValidationsHelper {
     /**

--- a/src/test/java/dev/filechampion/filechampion4j/FileValidatorJsonTest.java
+++ b/src/test/java/dev/filechampion/filechampion4j/FileValidatorJsonTest.java
@@ -20,6 +20,8 @@ import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import java.util.logging.Level;
@@ -404,7 +406,7 @@ public class FileValidatorJsonTest {
         FileValidator validator = new FileValidator(CONFIG_JSON_CHECKSUMS);
         ValidationResponse fileValidationResults = validator.validateFile("Documents", fileInBytes, fileName);
         assertTrue(fileValidationResults.isValid(), "Expected validation response to be valid");
-        assertEquals("SHA-256: " + calculateChecksum(fileInBytes), fileValidationResults.getFileChecksum(), "Expected checksums to match");
+        assertEquals(calculateChecksum(fileInBytes), fileValidationResults.getFileChecksums().get("SHA-256"), "Expected checksums to match");
     }
 
     // Test step timeout
@@ -648,8 +650,9 @@ public class FileValidatorJsonTest {
         ValidationResponse fileValidationResultsFail = validator.validateFile("SmallDocuments", fileInBytes, fileName);
         assertFalse(fileValidationResultsFail.isValid(), "Expected validation response to be invalid");
         ValidationResponse fileValidationResultsPass = validator.validateFile("LargeDocuments", fileInBytes, fileName);
+        Map<String, String> emptyMap = new HashMap<>();
         assertTrue(fileValidationResultsPass.isValid(), "Expected validation response to be valid");
-        assertEquals(fileValidationResultsPass.getFileChecksum(), "", "Expected response checksum to be empty");
+        assertEquals(emptyMap, fileValidationResultsPass.getFileChecksums(), "Expected response checksum to be empty");
     }
 
     // Helper methods

--- a/src/test/java/dev/filechampion/filechampion4j/FileValidatorTest.java
+++ b/src/test/java/dev/filechampion/filechampion4j/FileValidatorTest.java
@@ -19,6 +19,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import java.util.logging.LogManager;
 
@@ -249,9 +251,10 @@ public class FileValidatorTest {
         + "}");
         validator = new FileValidator(testLargeConfig);
         ValidationResponse fileValidationResults = validator.validateFile("Documents", fileInBytes, fileName, tempOutDirectory, "application/pdf");
+        Map<String,String> emptyMap = new HashMap<>();
         assertTrue(fileValidationResults.isValid(), "Expected validation response to be valid");
         assertFalse(fileValidationResults.resultsDetails().contains("Error"), "Expected results to be free of errors, got: " + fileValidationResults.resultsDetails());
-        assertEquals( "", fileValidationResults.getFileChecksum(), "Expected checksum to be empty, got: " + fileValidationResults.getFileChecksum());
+        assertEquals( emptyMap, fileValidationResults.getFileChecksums(), "Expected checksum to be empty, got: " + fileValidationResults.getFileChecksums());
     }
 
     // Test valid inputs with add_checksum false
@@ -263,9 +266,10 @@ public class FileValidatorTest {
         fileInBytes = generatePdfBytes(250000);
         fileName = "test&test.pdf";
         ValidationResponse fileValidationResults = validator.validateFile("LargeDocuments", fileInBytes, fileName);
+        Map<String,String> emptyMap = new HashMap<>();
         assertTrue(fileValidationResults.isValid(), "Expected validation response to be valid");
         assertFalse(fileValidationResults.resultsDetails().contains("Error"), "Expected results to be free of errors, got: " + fileValidationResults.resultsDetails());
-        assertEquals( "", fileValidationResults.getFileChecksum(), "Expected checksum to be empty, got: " + fileValidationResults.getFileChecksum());
+        assertEquals( emptyMap, fileValidationResults.getFileChecksums(), "Expected checksum to be empty, got: " + fileValidationResults.getFileChecksums());
     }
 
         
@@ -378,12 +382,12 @@ public class FileValidatorTest {
         ValidationResponse fileValidationResults = validator.validateFile("Documents", fileInBytes, fileName, "application/pdf");
         assertTrue(fileValidationResults.isValid(), "Expected validation response to be valid");
         assertFalse(fileValidationResults.resultsDetails().contains("Error"), "Expected results to be free of errors, got: " + fileValidationResults.resultsDetails());
-        String fileChecksumMD5 = calculateChecksum(fileInBytes, "MD5");
-        String fileChecksumSHA1 = calculateChecksum(fileInBytes, "SHA-1");
-        String fileChecksumSHA256 = calculateChecksum(fileInBytes, "SHA-256");
-        String fileChecksumSHA512 = calculateChecksum(fileInBytes, "SHA-512");
-        String expectedChecksumString = "MD5: " + fileChecksumMD5 + ", SHA-1: " + fileChecksumSHA1 + ", SHA-256: " + fileChecksumSHA256 + ", SHA-512: " + fileChecksumSHA512;
-        assertEquals(expectedChecksumString, fileValidationResults.getFileChecksum(), "Expected checksum to be " + expectedChecksumString + ", got: " + fileValidationResults.getFileChecksum());
+        Map<String, String> fileChecksums = new HashMap<>();
+        fileChecksums.put("MD5", calculateChecksum(fileInBytes, "MD5"));
+        fileChecksums.put("SHA-1", calculateChecksum(fileInBytes, "SHA-1"));
+        fileChecksums.put("SHA-256", calculateChecksum(fileInBytes, "SHA-256"));
+        fileChecksums.put("SHA-512", calculateChecksum(fileInBytes, "SHA-512"));
+        assertEquals(fileChecksums, fileValidationResults.getFileChecksums(), "Expected checksum to be " + fileChecksums.toString() + ", got: " + fileValidationResults.getFileChecksums());
     }
 
     // Test invalid checksum algorithm

--- a/src/test/java/dev/filechampion/filechampion4j/ValidationResponseTest.java
+++ b/src/test/java/dev/filechampion/filechampion4j/ValidationResponseTest.java
@@ -1,6 +1,9 @@
 package dev.filechampion.filechampion4j;
 
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -18,7 +21,8 @@ public class ValidationResponseTest {
         String resultsDetails = "Validation successful";
         String cleanFileName = "test-file.txt";
         byte[] fileBytes = new byte[] {0x01, 0x02, 0x03};
-        String fileChecksum = "abc123";
+        Map<String, String> fileChecksum = new HashMap<String, String>();
+        fileChecksum.put("SHA-256", "1234567890abcdef");
         String[] validFilePath = new String[] {"path/to/valid/file"};
 
         ValidationResponse response = new ValidationResponse(isValid, resultsInfo, resultsDetails, cleanFileName, fileBytes, fileChecksum, validFilePath);
@@ -29,7 +33,7 @@ public class ValidationResponseTest {
         Assertions.assertEquals(resultsDetails, response.resultsDetails(), "Expected resultsDetails to match input parameter");
         Assertions.assertEquals(cleanFileName, response.getCleanFileName(), "Expected cleanFileName to match input parameter");
         Assertions.assertArrayEquals(fileBytes, response.getFileBytes(), "Expected fileBytes to match input parameter");
-        Assertions.assertEquals(fileChecksum, response.getFileChecksum(), "Expected fileChecksum to match input parameter");
+        Assertions.assertEquals(fileChecksum, response.getFileChecksums(), "Expected fileChecksum to match input parameter");
         Assertions.assertArrayEquals(validFilePath, response.getValidFilePath(), "Expected validFilePath to match input parameter");
     }
 }

--- a/usage_example.MD
+++ b/usage_example.MD
@@ -53,7 +53,7 @@ public class Main {
                 String validMessage = String.format("%s is a valid document file.%n New file: %s, Checksum: %s",
                         fileValidationResults.resultsInfo(),
                         fileValidationResults.getValidFilePath().length == 0 ? "" : fileValidationResults.getValidFilePath()[0],
-                        fileValidationResults.getFileChecksum());
+                        fileValidationResults.getFileChecksums());
                 System.out.println(validMessage);
             } else {
                 // Print the results if the file is invalid


### PR DESCRIPTION
- Change validationresponse to return a map<String, String> with "ALGORITHM": "CHECKSUM"
- Updated callers and returns in FileValidator
- Updated tests with new return type
- Updated javadocs
TODO:
- Update DoxyGen
- Update Wiki
- Release and Deploy v0.9.8.3 with new checksums support